### PR TITLE
docs(dataform): fill placeholder index metadata

### DIFF
--- a/src/main/resources/metadata/index.yaml
+++ b/src/main/resources/metadata/index.yaml
@@ -1,8 +1,8 @@
 group: io.kestra.plugin.dataform
 name: "dataform"
 title: "Dataform"
-description: "Plugin Dataform for Kestra"
-body: ""
+description: "Tasks that run Dataform data transformations through the Dataform CLI."
+body: "Run the Dataform CLI in Kestra to compile, validate, and execute Dataform projects against your data warehouse. Provide the CLI `commands` to run and optional `beforeCommands` for setup, and pass credentials and project configuration via `env` and `inputFiles`; the task runs in a container (default `dataformco/dataform:latest`) or any configured task runner."
 videos: []
 createdBy: "Kestra Core Team"
 managedBy: "Kestra Core Team"


### PR DESCRIPTION
## Documentation review: plugin-dataform

Task-level doc pass over the single task (`cli.DataformCLI`), the two metadata YAMLs, and the how-to doc. Documentation only; no runtime behavior changes.

### Fix
- **`index.yaml`** — the `description` was placeholder text ("Plugin Dataform for Kestra") and the `body` was empty. Replaced with an accurate summary (`cli.yaml` already had a proper description and body).

`DataformCLI` (title, description, the Git-clone example with `{{ secret('...') }}` for the service-account JSON, all documented properties, `commands` correctly `@NotNull`), `cli.yaml`, the `cli` package-info, and the how-to were all accurate. `namespaceFiles`/`inputFiles`/`outputFiles` inherit their `@Schema` from the file interfaces. No `@Metric`, no code-level flags.